### PR TITLE
Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.php_cs.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,16 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+;
+
+return PhpCsFixer\Config::create()
+    ->setRules(array(
+        '@PSR1' => true,
+        '@PSR2' => true,
+        '@Symfony' => true,
+        'concat_space' => false,
+        'phpdoc_no_alias_tag' => false,
+    ))
+    ->setFinder($finder)
+;

--- a/plugins/inviteplugin.php
+++ b/plugins/inviteplugin.php
@@ -107,6 +107,13 @@ class inviteplugin extends phplistPlugin {
       if (!isBlackListed($userdata['email'])) {
         addUserToBlackList($userdata['email'],s('Blacklisted by the invitation plugin'));
       }
+        Sql_Query(sprintf(
+            'update %s
+            set confirmed = 0
+            where id = %d',
+            $GLOBALS['tables']['user'],
+            $userdata['id']
+        ));
     }
     ## if subscribe page is set, mark this subscriber for that page
     $sPage = getConfig('inviteplugin_subscribepage');

--- a/plugins/inviteplugin.php
+++ b/plugins/inviteplugin.php
@@ -23,7 +23,7 @@ class inviteplugin extends phplistPlugin {
       'allowempty' => 0,
       'min'=> 0,
       'max'=> 999999,
-      'category'=> 'transactional',
+      'category'=> 'Invite plugin',
     ),
     "inviteplugin_targetlist" => array (
       'value' => 0,
@@ -32,7 +32,7 @@ class inviteplugin extends phplistPlugin {
       'allowempty' => 0,
       'min'=> 0,
       'max'=> 999999,
-      'category'=> 'segmentation',
+      'category'=> 'Invite plugin',
     ),
   );
   

--- a/plugins/inviteplugin.php
+++ b/plugins/inviteplugin.php
@@ -1,137 +1,109 @@
 <?php
 
 /**
- * v0.3 - 2013-08-29 - add config for target list, where subscribers who confirm are added to
- * v0.2 - 2013-08-28 - set invite via the "sendformat" instead of adding it's own tab
- * v0.1 - initial 
- * 
+ * v0.3 - 2013-08-29 - add config for target list, where subscribers who confirm are added to.
+ * v0.2 - 2013-08-28 - set invite via the "sendformat" instead of adding it's own tab.
+ * v0.1 - initial.
  */
-
-class inviteplugin extends phplistPlugin {
-  public $name = "Invite plugin for phpList";
-  public $coderoot = '';
-  public $version = "0.3";
-  public $authors = 'Michiel Dethmers';
-  public $enabled = 1;
-  public $description = 'Send an invite to subscribe to the phpList mailing system';
-  public $documentationUrl = 'https://resources.phplist.com/plugin/invite';
-  public $settings = array(
-    "inviteplugin_subscribepage" => array (
-      'value' => 0,
-      'description' => 'Subscribe page for invitation responses',
-      'type' => "integer",
-      'allowempty' => 0,
-      'min'=> 0,
-      'max'=> 999999,
-      'category'=> 'Invite plugin',
-    ),
-    "inviteplugin_targetlist" => array (
-      'value' => 0,
-      'description' => 'Add subscribers confirming an invitation to this list',
-      'type' => "integer",
-      'allowempty' => 0,
-      'min'=> 0,
-      'max'=> 999999,
-      'category'=> 'Invite plugin',
-    ),
-  );
-  
-  function __construct() {
-    parent::phplistplugin();
-  }
-
-  function adminmenu() {
-    return array(
+class inviteplugin extends phplistPlugin
+{
+    public $name = 'Invite plugin for phpList';
+    public $coderoot = '';
+    public $version = '0.3';
+    public $authors = 'Michiel Dethmers';
+    public $enabled = 1;
+    public $description = 'Send an invite to subscribe to the phpList mailing system';
+    public $documentationUrl = 'https://resources.phplist.com/plugin/invite';
+    public $settings = array(
+        'inviteplugin_subscribepage' => array(
+            'value' => 0,
+            'description' => 'Subscribe page for invitation responses',
+            'type' => 'integer',
+            'allowempty' => 0,
+            'min' => 0,
+            'max' => 999999,
+            'category' => 'Invite plugin',
+        ),
+        'inviteplugin_targetlist' => array(
+            'value' => 0,
+            'description' => 'Add subscribers confirming an invitation to this list',
+            'type' => 'integer',
+            'allowempty' => 0,
+            'min' => 0,
+            'max' => 999999,
+            'category' => 'Invite plugin',
+        ),
     );
-  }
-  
-  function sendFormats() {
-    return array ('invite' => s('Invite'));
-  }
-  
-  function XsendMessageTab($messageid = 0, $data = array ()) {
-    if (!$this->enabled)
-      return null;
-      
-    $checkbox = '<input type="radio" name="sendInvite" value="1" ';
-    if (!empty($data['sendInvite'])) {
-      $checkbox .= ' checked="checked"';
+
+    public function adminmenu()
+    {
+        return array();
     }
-    $checkbox .= '/> '. s('Send as invitation');
-    $checkbox .= '<input type="radio" name="sendInvite" value="0" ';
-    if (empty($data['sendInvite'])) {
-      $checkbox .= ' checked="checked"';
+
+    public function sendFormats()
+    {
+        return array('invite' => s('Invite'));
     }
-    $checkbox .= '/> '. s('Do not send as invitation');
 
-    return $checkbox;
-  }
-
-  function upgrade($previous) {
-    parent::upgrade($previous);
-    return true;
-  }
-  
-  function XsendMessageTabTitle($messageid = 0) {
-    if (!$this->enabled)
-      return null;
-
-    return s('Invite');
-  }
-  
-  function allowMessageToBeQueued($messagedata = array()) {
-    ## we only need to check if this is sent as an invite
-    if ($messagedata['sendformat'] == 'invite') {
-      $cnt = '';
-      $hasConfirmationLink = false;
-      foreach ($messagedata as $key => $val) {
-        if (!is_array($val)) {
-          $cnt .= $key .' = '.$val."\n";
+    public function allowMessageToBeQueued($messagedata = array())
+    {
+        // we only need to check if this is sent as an invite
+        if ($messagedata['sendformat'] == 'invite') {
+            $hasConfirmationLink = false;
+            foreach ($messagedata as $key => $val) {
+                if (is_string($val)) {
+                    $hasConfirmationLink = $hasConfirmationLink || (strpos($val, '[CONFIRMATIONURL]') !== false);
+                }
+            }
+            if (!$hasConfirmationLink) {
+                return $GLOBALS['I18N']->get('Your campaign does not contain a the confirmation URL placeholder, which is necessary for an invite mailing. Please add [CONFIRMATIONURL] to the footer or content of the campaign.');
+            }
         }
-        if (is_string($val)) {
-          $hasConfirmationLink = $hasConfirmationLink ||
-            (strpos($val,'[CONFIRMATIONURL]') !== false || strpos($val,'[CONFIRMATIONURL]') !== false);
-        }
-      }
-      if (!$hasConfirmationLink) {
-        return $GLOBALS['I18N']->get('Your campaign does not contain a the confirmation URL placeholder, which is necessary for an invite mailing. Please add [CONFIRMATIONURL] to the footer or content of the campaign.');
-      }
-    }
-    
-    return '';
-  }
 
-  function processSendSuccess($messageid, $userdata, $isTestMail = false) {
-    $messagedata = loadMessageData($messageid);
-    if (!$isTestMail && $messagedata['sendformat'] == 'invite') {  
-      if (!isBlackListed($userdata['email'])) {
-        addUserToBlackList($userdata['email'],s('Blacklisted by the invitation plugin'));
-      }
-        Sql_Query(sprintf(
-            'update %s
-            set confirmed = 0
-            where id = %d',
-            $GLOBALS['tables']['user'],
-            $userdata['id']
-        ));
+        return '';
     }
-    ## if subscribe page is set, mark this subscriber for that page
-    $sPage = getConfig('inviteplugin_subscribepage');
-    if (!empty($sPage)) {
-      Sql_Query(sprintf('update %s set subscribepage = %d where id = %d',$GLOBALS['tables']['user'],$sPage,$userdata['id']));
+
+    public function processSendSuccess($messageid, $userdata, $isTestMail = false)
+    {
+        $messagedata = loadMessageData($messageid);
+        if (!$isTestMail && $messagedata['sendformat'] == 'invite') {
+            if (!isBlackListed($userdata['email'])) {
+                addUserToBlackList($userdata['email'], s('Blacklisted by the invitation plugin'));
+            }
+            Sql_Query(sprintf(
+                'update %s
+                set confirmed = 0
+                where id = %d',
+                $GLOBALS['tables']['user'],
+                $userdata['id']
+            ));
+        }
+        // if subscribe page is set, mark this subscriber for that page
+        $sPage = getConfig('inviteplugin_subscribepage');
+        if (!empty($sPage)) {
+            Sql_Query(sprintf(
+                'update %s set subscribepage = %d where id = %d',
+                $GLOBALS['tables']['user'],
+                $sPage,
+                $userdata['id']
+            ));
+        }
     }
-  }
-  
-  
-  function subscriberConfirmation($subscribepageID,$userdata = array()) {
-    $sPage = getConfig('inviteplugin_subscribepage');
-    $newList = getConfig('inviteplugin_targetlist');
-    if (!empty($sPage) && !empty($newList) && $sPage == $subscribepageID) {
-      if ($userdata['blacklisted']) { ## the subscriber has not been unblacklisted yet at this stage
-        Sql_Query(sprintf('insert ignore into %s (userid,listid) values(%d,%d)',$GLOBALS['tables']['listuser'],$userdata['id'],$newList));
-      }
+
+    public function subscriberConfirmation($subscribepageID, $userdata = array())
+    {
+        $sPage = getConfig('inviteplugin_subscribepage');
+        $newList = getConfig('inviteplugin_targetlist');
+        if (!empty($sPage) && !empty($newList) && $sPage == $subscribepageID) {
+            if ($userdata['blacklisted']) {
+                // the subscriber has not been unblacklisted yet at this stage
+                Sql_Query(sprintf(
+                    'insert ignore into %s (userid,listid) values(%d,%d)',
+                    $GLOBALS['tables']['listuser'],
+                    $userdata['id'],
+                    $newList
+                ));
+            }
+        }
     }
-  }
-  
-  
 }

--- a/plugins/inviteplugin.php
+++ b/plugins/inviteplugin.php
@@ -77,16 +77,16 @@ class inviteplugin extends phplistPlugin
                 $GLOBALS['tables']['user'],
                 $userdata['id']
             ));
-        }
-        // if subscribe page is set, mark this subscriber for that page
-        $sPage = getConfig('inviteplugin_subscribepage');
-        if (!empty($sPage)) {
-            Sql_Query(sprintf(
-                'update %s set subscribepage = %d where id = %d',
-                $GLOBALS['tables']['user'],
-                $sPage,
-                $userdata['id']
-            ));
+            // if subscribe page is set, mark this subscriber for that page
+            $sPage = getConfig('inviteplugin_subscribepage');
+            if (!empty($sPage)) {
+                Sql_Query(sprintf(
+                    'update %s set subscribepage = %d where id = %d',
+                    $GLOBALS['tables']['user'],
+                    $sPage,
+                    $userdata['id']
+                ));
+            }
         }
     }
 

--- a/plugins/inviteplugin.php
+++ b/plugins/inviteplugin.php
@@ -1,6 +1,7 @@
 <?php
 
 /**
+ * v0.4 - 2018-02-01 - bug fixes.
  * v0.3 - 2013-08-29 - add config for target list, where subscribers who confirm are added to.
  * v0.2 - 2013-08-28 - set invite via the "sendformat" instead of adding it's own tab.
  * v0.1 - initial.
@@ -9,7 +10,7 @@ class inviteplugin extends phplistPlugin
 {
     public $name = 'Invite plugin for phpList';
     public $coderoot = '';
-    public $version = '0.3';
+    public $version = '0.4';
     public $authors = 'Michiel Dethmers';
     public $enabled = 1;
     public $description = 'Send an invite to subscribe to the phpList mailing system';


### PR DESCRIPTION
Make subscriber unconfirmed when sending the invite campaign as mentioned in https://github.com/michield/phplist-plugin-invite/issues/1
Fix error in changing subscribe page, which was happening for all campaigns, not only invites.
For clarity, put the plugin settings in their own group
Apply PHP CS Fixer.